### PR TITLE
Update to work on 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat 0.59.0
+julia 0.7

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -1,4 +1,4 @@
-VERSION < v"1.0.0" && __precompile__()
+__precompile__()
 
 module Sobol
 export SobolSeq, ScaledSobolSeq, iterate!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,10 @@
-using Sobol, Compat
-using Compat.Test
+using Sobol, Test
 
-# compare results with results from C++ code sobol.cc published on 
+# compare results with results from C++ code sobol.cc published on
 # http://web.maths.unsw.edu.au/~fkuo/sobol/
 # with new-joe-kuo-6.21201 file used as input.
 #
-# Command line used to generate output is 
+# Command line used to generate output is
 #  ./sobol $N 1024 new-joe-kuo-6.21201 > exp_results_$N
 #
 # For each of the dimensions below
@@ -22,7 +21,7 @@ for dim in dimensions
             values = [parse(Float64, item) for item in split(line)]
             if length(values) > 0
                 @test x == values
-                next!(s, x)
+                iterate!(s, x)
             end
         end
     end
@@ -30,4 +29,4 @@ end
 
 # issue #8
 using Base.Iterators: take
-@test [x[1] for x in collect(take(Sobol.SobolSeq(1),5))] == [0.5,0.75,0.25,0.375,0.875]
+@test [x[1] for x in collect(take(Sobol.SobolSeq(1), 5))] == [0.5,0.75,0.25,0.375,0.875]


### PR DESCRIPTION
Hi @stevengj 

Thanks for (many) useful package(s).

I needed to use `Sobol.jl` and am trying to move everything I have to 1.0, so thought I'd spend a few minutes making sure it all worked.

Most of what this entailed was renaming the `next` methods. I also killed off `Compat` and required 0.7+ (though I don't know if this is desired behavior).

Tests pass. Let me know if I can do anything else to fix this up.