### PR TITLE
Enable `skip(s, n, exact=true)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ facility is provided by:
 skip(s, n)
 ```
 
+Skipping exactly `n` elements is also possible:
+
+```
+skip(s, n, exact=true)
+```
+
 ## Example
 
 Here is a simple example, generating 1024 points in two dimensions and

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -86,11 +86,7 @@ next!(s::SobolSeq) = next!(s, Array{Float64,1}(undef, ndims(s)))
 # skip!(s, n, exact=true) skips m = n
 
 function skip!(s::SobolSeq, n::Integer, x; exact=false)
-    if exact
-      nskip = n
-    else
-    nskip = 1 << floor(Int,log2(n))
-    end
+    nskip = exact ? n : 1 << floor(Int,log2(n))
     for unused=1:nskip; next!(s,x); end
     return nothing
 end

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -80,12 +80,21 @@ next!(s::SobolSeq) = next!(s, Array{Float64,1}(undef, ndims(s)))
 # adopt the suggestion of the Joe and Kuo paper, which in turn
 # is taken from Acworth et al (1998), of skipping a number of
 # points equal to the largest power of 2 smaller than n
-function skip!(s::SobolSeq, n::Integer, x)
+# if exactly n points are to be skipped, use the keyword exact=true.
+# 
+# skip!(s, n) skips m such that 2^m < n < 2^(m+1)
+# skip!(s, n, exact=true) skips m = n
+
+function skip!(s::SobolSeq, n::Integer, x; exact=false)
+    if exact
+      nskip = n
+    else
     nskip = 1 << floor(Int,log2(n))
+    end
     for unused=1:nskip; next!(s,x); end
     return nothing
 end
-Base.skip(s::SobolSeq, n::Integer) = skip!(s, n, Array{Float64,1}(undef, ndims(s)))
+Base.skip(s::SobolSeq, n::Integer; exact=false) = skip!(s, n, Array{Float64,1}(undef, ndims(s)); exact=exact)
 
 function Base.show(io::IO, s::SobolSeq)
     print(io, "$(ndims(s))-dimensional Sobol sequence on [0,1]^$(ndims(s))")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,3 +47,18 @@ end
     @test SobolSeq(N,lb,ub) isa ScaledSobolSeq{3}
     @test_throws BoundsError SobolSeq(2,lb,ub)
 end
+
+@testset "skip exactly n" begin
+    # issue #22
+    # want to get the nth element
+    n = 10
+
+    s1 = SobolSeq(1)
+    x1 = [next!(s1)[1] for i in 1:n][n]
+
+    s2 = SobolSeq(1)
+    skip(s2, n-1, exact=true)
+    x2 = next!(s2)[1]
+
+    @test x1 == x2
+end


### PR DESCRIPTION
implements the feature discussed in #22