### PR TITLE
generic ScaledSobolSeq element types

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,10 +41,12 @@ end
     ub = [1,3,2]
     N = length(lb)
     s = SobolSeq(lb,ub)
-    @test s isa ScaledSobolSeq{3}
+    @test s isa ScaledSobolSeq{3,Int}
+    @test eltype(s) == Vector{Float64}
+    @test eltype(SobolSeq(Float32.(lb),Float32.(ub))) == Vector{Float32}
     @test first(s) == [0,1.5,1]
     @test first(SobolSeq((x for x in lb), (x for x in ub))) == [0,1.5,1]
-    @test SobolSeq(N,lb,ub) isa ScaledSobolSeq{3}
+    @test SobolSeq(N,lb,ub) isa ScaledSobolSeq{3,Int}
     @test_throws BoundsError SobolSeq(2,lb,ub)
 end
 


### PR DESCRIPTION
This PR allows the ScaledSobolSeq to have more generic element types, determined by the element types of the lb and ub endpoints.

(Since the underlying SobolSeq values are computed exactly in double precision, being 32-bit integers multiplied by small powers of 2, they can be losslessly converted to other floating-point types, and then scaled to other intervals according to the precision of the endpoints.)