### PR TITLE
Clearer description of `skip()` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Skipping exactly `n` elements is also possible:
 skip(s, n, exact=true)
 ```
 
-`skip` returns `s`, so you can simply do `s = skip(SobolSeq(N))` or similar.
+`skip` mutates and returns `s`, so you can simply do `s = skip(SobolSeq(lb, ub), n)` or similar.
 
 ## Example
 


### PR DESCRIPTION
Make it clear `skip()` mutates `s`