### PR TITLE
Remove static dimension type parameter

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "Sobol"
 uuid = "ed01d8cd-4d21-5b2a-85b4-cc3bdc58bad4"
-version = "1.5.0"
+version = "2.0.0"
 
 [deps]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "1"
+julia = "1.8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-julia = "1.8"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -4,17 +4,17 @@ export SobolSeq, ScaledSobolSeq, next!
 
 include("soboldata.jl") #loads `sobol_a` and `sobol_minit`
 
-abstract type AbstractSobolSeq{N} end
+abstract type AbstractSobolSeq end
 
-# N iis the dimension of sequence being generated
-mutable struct SobolSeq{N} <: AbstractSobolSeq{N}
+mutable struct SobolSeq <: AbstractSobolSeq
+    const ndims::Int # dimension of sequence being generated
     m::Array{UInt32,2} #array of size (sdim, 32)
     x::Array{UInt32,1} #previous x = x_n, array of length sdim
     b::Array{UInt32,1} #position of fixed point in x[i] is after bit b[i]
     n::UInt32 #number of x's generated so far
 end
 
-ndims(s::AbstractSobolSeq{N}) where {N} = N::Int
+Base.ndims(s::SobolSeq) = s.ndims
 
 function SobolSeq(N::Int)
     (N < 0 || N > (length(sobol_a) + 1)) && error("invalid Sobol dimension")
@@ -22,9 +22,9 @@ function SobolSeq(N::Int)
     m = ones(UInt32, (N, 32))
 
     #special cases
-    N == 0 && return(SobolSeq{0})(m,UInt32[],UInt32[],zero(UInt32))
+    N == 0 && return SobolSeq(0,m,UInt32[],UInt32[],zero(UInt32))
     #special cases 1
-    N == 1 && return(SobolSeq{N}(m,UInt32[0],UInt32[0],zero(UInt32)))
+    N == 1 && return SobolSeq(1,m,UInt32[0],UInt32[0],zero(UInt32))
 
     for i = 2:N
         a = sobol_a[i-1]
@@ -42,7 +42,7 @@ function SobolSeq(N::Int)
             end
         end
     end
-    SobolSeq{N}(m,zeros(UInt32,N),zeros(UInt32,N),zero(UInt32))
+    SobolSeq(N,m,zeros(UInt32,N),zeros(UInt32,N),zero(UInt32))
 end
 SobolSeq(N::Integer) = SobolSeq(Int(N))
 
@@ -115,20 +115,21 @@ Base.IteratorEltype(::Type{<:AbstractSobolSeq}) = Base.HasEltype()
 
 # Convenience wrapper for scaled Sobol sequences
 
-struct ScaledSobolSeq{N,T} <: AbstractSobolSeq{N}
-    s::SobolSeq{N}
+struct ScaledSobolSeq{T} <: AbstractSobolSeq
+    s::SobolSeq
     lb::Vector{T}
     ub::Vector{T}
-    function ScaledSobolSeq{N,T}(lb::Vector{T}, ub::Vector{T}) where {N,T}
-        length(lb)==length(ub)==N || throw(DimensionMismatch("lb and ub do not have length $N"))
-        new(SobolSeq(N), lb, ub)
+    function ScaledSobolSeq{T}(lb::Vector{T}, ub::Vector{T}) where {T}
+        length(lb)==length(ub) || throw(DimensionMismatch("lb and ub do not have same length"))
+        new(SobolSeq(length(lb)), lb, ub)
     end
 end
 function SobolSeq(N::Integer, lb, ub)
     T = typeof(sum(ub) - sum(lb))
-    ScaledSobolSeq{Int(N),T}(copyto!(Vector{T}(undef,N), lb), copyto!(Vector{T}(undef,N), ub))
+    ScaledSobolSeq{T}(copyto!(Vector{T}(undef,N), lb), copyto!(Vector{T}(undef,N), ub))
 end
 SobolSeq(lb, ub) = SobolSeq(length(lb), lb, ub)
+Base.ndims(s::ScaledSobolSeq) = ndims(s.s)
 
 function next!(s::SobolSeq, x::AbstractVector{<:AbstractFloat},
                lb::AbstractVector, ub::AbstractVector)
@@ -139,20 +140,20 @@ function next!(s::SobolSeq, x::AbstractVector{<:AbstractFloat},
     end
     return x
 end
-function next!(s::SobolSeq{N}, lb::AbstractVector, ub::AbstractVector) where {N}
+function next!(s::SobolSeq, lb::AbstractVector, ub::AbstractVector)
     T = typeof(float((zero(eltype(ub)) - zero(eltype(lb)))))
-    next!(s, Vector{T}(undef, N), lb, ub)
+    next!(s, Vector{T}(undef, ndims(s)), lb, ub)
 end
 
 next!(s::ScaledSobolSeq, x::AbstractVector{<:AbstractFloat}) = next!(s.s, x, s.lb, s.ub)
-next!(s::ScaledSobolSeq{N,T}) where {N,T} = next!(s.s, Vector{float(T)}(undef, N), s.lb, s.ub)
-Base.eltype(::Type{ScaledSobolSeq{N,T}}) where {N,T} = Vector{float(T)}
+next!(s::ScaledSobolSeq{T}) where {T} = next!(s.s, Vector{float(T)}(undef, ndims(s)), s.lb, s.ub)
+Base.eltype(::Type{ScaledSobolSeq{T}}) where {T} = Vector{float(T)}
 
 Base.skip(s::ScaledSobolSeq, n; exact = false) = (skip(s.s, n; exact = exact); s)
 
-function Base.show(io::IO, s::ScaledSobolSeq{N,T}) where {N,T}
+function Base.show(io::IO, s::ScaledSobolSeq{T}) where {T}
     lb = s.lb; ub = s.ub
-    print(io, "$N-dimensional scaled $(float(T)) Sobol sequence on [$(lb[1]),$(ub[1])]")
+    print(io, "$(ndims(s))-dimensional scaled $(float(T)) Sobol sequence on [$(lb[1]),$(ub[1])]")
     cnt = 1
     for i = 2:N
         if lb[i] == lb[i-1] && ub[i] == ub[i-1]
@@ -170,9 +171,9 @@ function Base.show(io::IO, s::ScaledSobolSeq{N,T}) where {N,T}
     end
 end
 
-function Base.show(io::IO, ::MIME"text/html", s::ScaledSobolSeq{N,T}) where {N,T}
+function Base.show(io::IO, ::MIME"text/html", s::ScaledSobolSeq{T}) where {T}
     lb = s.lb; ub = s.ub
-    print(io, "$N-dimensional scaled $(float(T)) Sobol sequence on [$(lb[1]),$(ub[1])]")
+    print(io, "$(ndims(s))-dimensional scaled $(float(T)) Sobol sequence on [$(lb[1]),$(ub[1])]")
     cnt = 1
     for i = 2:N
         if lb[i] == lb[i-1] && ub[i] == ub[i-1]

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -15,15 +15,16 @@ end
 
 Base.ndims(s::SobolSeq) = length(s.x)
 
-function SobolSeq{X}(N::Integer) where {X<:AbstractVector{UInt32}}
+function SobolSeq(x::AbstractVector{UInt32})
+    N = length(x)
     (N < 0 || N > (length(sobol_a) + 1)) && error("invalid Sobol dimension")
 
     m = ones(UInt32, (N, 32))
 
     #special cases
-    N == 0 && return SobolSeq(m,UInt32[],X(undef,0),zero(UInt32))
+    N == 0 && return SobolSeq(m,UInt32[],x,zero(UInt32))
     #special cases 1
-    N == 1 && return SobolSeq(m,UInt32[0],fill!(X(undef,1),zero(UInt32)),zero(UInt32))
+    N == 1 && return SobolSeq(m,UInt32[0],fill!(x,zero(UInt32)),zero(UInt32))
 
     for i = 2:N
         a = sobol_a[i-1]
@@ -41,9 +42,9 @@ function SobolSeq{X}(N::Integer) where {X<:AbstractVector{UInt32}}
             end
         end
     end
-    SobolSeq(m,zeros(UInt32,N),fill!(X(undef,N),zero(UInt32)),zero(UInt32))
+    SobolSeq(m,zeros(UInt32,N),fill!(x,zero(UInt32)),zero(UInt32))
 end
-SobolSeq(args...) = SobolSeq{Vector{UInt32}}(args...)
+SobolSeq(N::Integer) = SobolSeq(Vector{UInt32}(undef, N))
 
 function next!(s::SobolSeq, x::AbstractVector{<:AbstractFloat})
     length(x) != ndims(s) && throw(BoundsError())
@@ -114,20 +115,27 @@ Base.IteratorEltype(::Type{<:AbstractSobolSeq}) = Base.HasEltype()
 
 # Convenience wrapper for scaled Sobol sequences
 
-struct ScaledSobolSeq{T,X<:AbstractVector{UInt32}} <: AbstractSobolSeq
+struct ScaledSobolSeq{T,X<:AbstractVector{UInt32},B<:AbstractVector{T}} <: AbstractSobolSeq
     s::SobolSeq{X}
-    lb::Vector{T}
-    ub::Vector{T}
-    function ScaledSobolSeq{T,X}(lb::Vector{T}, ub::Vector{T}) where {T,X<:AbstractVector{UInt32}}
-        length(lb)==length(ub) || throw(DimensionMismatch("lb and ub do not have same length"))
-        new{T,X}(SobolSeq{X}(length(lb)), lb, ub)
+    lb::B
+    ub::B
+    function ScaledSobolSeq(x::X, lb::B, ub::B) where {T,X<:AbstractVector{UInt32},B<:AbstractVector{T}}
+        length(x)==length(lb)==length(ub) || throw(DimensionMismatch("x, lb, and ub do not all have same length"))
+        new{T,X,B}(SobolSeq(x), lb, ub)
     end
 end
-function SobolSeq{X}(N::Integer, lb, ub) where {X<:AbstractVector{UInt32}}
-    T = typeof(sum(ub) - sum(lb))
-    ScaledSobolSeq{T,X}(copyto!(Vector{T}(undef,N), lb), copyto!(Vector{T}(undef,N), ub))
+function SobolSeq(x::AbstractVector{UInt32}, lb::B, ub::B) where {B}
+    if Base.IteratorEltype(B) === Base.HasEltype()
+        T = eltype(B)
+    else
+        i = iterate(lb)
+        isnothing(i) && error("Cannot determine eltype of empty iterator")
+        T = typeof(i[1])
+    end
+    ScaledSobolSeq(x, copyto!(Vector{T}(undef,length(x)), lb), copyto!(Vector{T}(undef, length(x)), ub))
 end
-SobolSeq{X}(lb, ub) where {X<:AbstractVector{UInt32}} = SobolSeq{X}(length(lb), lb, ub)
+SobolSeq(N::Integer, lb, ub) = SobolSeq(Vector{UInt32}(undef, N), lb, ub)
+SobolSeq(lb, ub) = SobolSeq(length(lb), lb, ub)
 Base.ndims(s::ScaledSobolSeq) = ndims(s.s)
 
 function next!(s::SobolSeq, x::AbstractVector{<:AbstractFloat},

--- a/src/Sobol.jl
+++ b/src/Sobol.jl
@@ -6,25 +6,24 @@ include("soboldata.jl") #loads `sobol_a` and `sobol_minit`
 
 abstract type AbstractSobolSeq end
 
-mutable struct SobolSeq <: AbstractSobolSeq
-    const ndims::Int # dimension of sequence being generated
-    m::Array{UInt32,2} #array of size (sdim, 32)
-    x::Array{UInt32,1} #previous x = x_n, array of length sdim
-    b::Array{UInt32,1} #position of fixed point in x[i] is after bit b[i]
+mutable struct SobolSeq{X<:AbstractVector{UInt32}} <: AbstractSobolSeq
+    m::Matrix{UInt32} #array of size (sdim, 32)
+    x::X #previous x = x_n, array of length sdim
+    b::Vector{UInt32} #position of fixed point in x[i] is after bit b[i]
     n::UInt32 #number of x's generated so far
 end
 
-Base.ndims(s::SobolSeq) = s.ndims
+Base.ndims(s::SobolSeq) = length(s.x)
 
-function SobolSeq(N::Int)
+function SobolSeq{X}(N::Integer) where {X<:AbstractVector{UInt32}}
     (N < 0 || N > (length(sobol_a) + 1)) && error("invalid Sobol dimension")
 
     m = ones(UInt32, (N, 32))
 
     #special cases
-    N == 0 && return SobolSeq(0,m,UInt32[],UInt32[],zero(UInt32))
+    N == 0 && return SobolSeq(m,UInt32[],X(undef,0),zero(UInt32))
     #special cases 1
-    N == 1 && return SobolSeq(1,m,UInt32[0],UInt32[0],zero(UInt32))
+    N == 1 && return SobolSeq(m,UInt32[0],fill!(X(undef,1),zero(UInt32)),zero(UInt32))
 
     for i = 2:N
         a = sobol_a[i-1]
@@ -42,9 +41,9 @@ function SobolSeq(N::Int)
             end
         end
     end
-    SobolSeq(N,m,zeros(UInt32,N),zeros(UInt32,N),zero(UInt32))
+    SobolSeq(m,zeros(UInt32,N),fill!(X(undef,N),zero(UInt32)),zero(UInt32))
 end
-SobolSeq(N::Integer) = SobolSeq(Int(N))
+SobolSeq(args...) = SobolSeq{Vector{UInt32}}(args...)
 
 function next!(s::SobolSeq, x::AbstractVector{<:AbstractFloat})
     length(x) != ndims(s) && throw(BoundsError())
@@ -72,7 +71,7 @@ function next!(s::SobolSeq, x::AbstractVector{<:AbstractFloat})
     end
     return x
 end
-next!(s::SobolSeq) = next!(s, Array{Float64,1}(undef, ndims(s)))
+next!(s::SobolSeq) = next!(s, Vector{Float64}(undef, ndims(s)))
 
 # if we know in advance how many points (n) we want to compute, then
 # adopt a suggestion similar to the Joe and Kuo paper, which in turn
@@ -95,7 +94,7 @@ function skip!(s::SobolSeq, n::Integer, x; exact=false)
     for unused=1:nskip; next!(s,x); end
     return s
 end
-Base.skip(s::SobolSeq, n::Integer; exact=false) = skip!(s, n, Array{Float64,1}(undef, ndims(s)); exact=exact)
+Base.skip(s::SobolSeq, n::Integer; exact=false) = skip!(s, n, Vector{Float64}(undef, ndims(s)); exact=exact)
 
 function Base.show(io::IO, s::SobolSeq)
     print(io, "$(ndims(s))-dimensional Sobol sequence on [0,1]^$(ndims(s))")
@@ -115,20 +114,20 @@ Base.IteratorEltype(::Type{<:AbstractSobolSeq}) = Base.HasEltype()
 
 # Convenience wrapper for scaled Sobol sequences
 
-struct ScaledSobolSeq{T} <: AbstractSobolSeq
-    s::SobolSeq
+struct ScaledSobolSeq{T,X<:AbstractVector{UInt32}} <: AbstractSobolSeq
+    s::SobolSeq{X}
     lb::Vector{T}
     ub::Vector{T}
-    function ScaledSobolSeq{T}(lb::Vector{T}, ub::Vector{T}) where {T}
+    function ScaledSobolSeq{T,X}(lb::Vector{T}, ub::Vector{T}) where {T,X<:AbstractVector{UInt32}}
         length(lb)==length(ub) || throw(DimensionMismatch("lb and ub do not have same length"))
-        new(SobolSeq(length(lb)), lb, ub)
+        new{T,X}(SobolSeq{X}(length(lb)), lb, ub)
     end
 end
-function SobolSeq(N::Integer, lb, ub)
+function SobolSeq{X}(N::Integer, lb, ub) where {X<:AbstractVector{UInt32}}
     T = typeof(sum(ub) - sum(lb))
-    ScaledSobolSeq{T}(copyto!(Vector{T}(undef,N), lb), copyto!(Vector{T}(undef,N), ub))
+    ScaledSobolSeq{T,X}(copyto!(Vector{T}(undef,N), lb), copyto!(Vector{T}(undef,N), ub))
 end
-SobolSeq(lb, ub) = SobolSeq(length(lb), lb, ub)
+SobolSeq{X}(lb, ub) where {X<:AbstractVector{UInt32}} = SobolSeq{X}(length(lb), lb, ub)
 Base.ndims(s::ScaledSobolSeq) = ndims(s.s)
 
 function next!(s::SobolSeq, x::AbstractVector{<:AbstractFloat},
@@ -147,7 +146,7 @@ end
 
 next!(s::ScaledSobolSeq, x::AbstractVector{<:AbstractFloat}) = next!(s.s, x, s.lb, s.ub)
 next!(s::ScaledSobolSeq{T}) where {T} = next!(s.s, Vector{float(T)}(undef, ndims(s)), s.lb, s.ub)
-Base.eltype(::Type{ScaledSobolSeq{T}}) where {T} = Vector{float(T)}
+Base.eltype(::Type{<:ScaledSobolSeq{T}}) where {T} = Vector{float(T)}
 
 Base.skip(s::ScaledSobolSeq, n; exact = false) = (skip(s.s, n; exact = exact); s)
 
@@ -155,7 +154,7 @@ function Base.show(io::IO, s::ScaledSobolSeq{T}) where {T}
     lb = s.lb; ub = s.ub
     print(io, "$(ndims(s))-dimensional scaled $(float(T)) Sobol sequence on [$(lb[1]),$(ub[1])]")
     cnt = 1
-    for i = 2:N
+    for i = 2:ndims(s)
         if lb[i] == lb[i-1] && ub[i] == ub[i-1]
             cnt += 1
         else
@@ -175,7 +174,7 @@ function Base.show(io::IO, ::MIME"text/html", s::ScaledSobolSeq{T}) where {T}
     lb = s.lb; ub = s.ub
     print(io, "$(ndims(s))-dimensional scaled $(float(T)) Sobol sequence on [$(lb[1]),$(ub[1])]")
     cnt = 1
-    for i = 2:N
+    for i = 2:ndims(s)
         if lb[i] == lb[i-1] && ub[i] == ub[i-1]
             cnt += 1
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,12 +41,13 @@ end
     ub = [1,3,2]
     N = length(lb)
     s = SobolSeq(lb,ub)
-    @test s isa ScaledSobolSeq{3,Int}
+    @test s isa ScaledSobolSeq{Int} && ndims(s) == 3
     @test eltype(s) == Vector{Float64}
     @test eltype(SobolSeq(Float32.(lb),Float32.(ub))) == Vector{Float32}
     @test first(s) == [0,1.5,1]
     @test first(SobolSeq((x for x in lb), (x for x in ub))) == [0,1.5,1]
-    @test SobolSeq(N,lb,ub) isa ScaledSobolSeq{3,Int}
+    s = SobolSeq(N,lb,ub)
+    @test s isa ScaledSobolSeq{Int} && ndims(s) == 3
     @test_throws BoundsError SobolSeq(2,lb,ub)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ using Sobol, Test
     for dim in dimensions
         println("Testing dimension $(dim)")
         open(joinpath(dirname(@__FILE__), "results", "exp_results_$(dim)")) do exp_results_file
-            s = SobolSeq(dim)
+            s = @inferred SobolSeq(dim)
             x = zeros(dim)
             for line in eachline(exp_results_file)
                 values = [parse(Float64, item) for item in split(line)]
@@ -40,13 +40,13 @@ end
     lb = [-1,0,0]
     ub = [1,3,2]
     N = length(lb)
-    s = SobolSeq(lb,ub)
+    s = @inferred SobolSeq(lb,ub)
     @test s isa ScaledSobolSeq{Int} && ndims(s) == 3
     @test eltype(s) == Vector{Float64}
     @test eltype(SobolSeq(Float32.(lb),Float32.(ub))) == Vector{Float32}
     @test first(s) == [0,1.5,1]
     @test first(SobolSeq((x for x in lb), (x for x in ub))) == [0,1.5,1]
-    s = SobolSeq(N,lb,ub)
+    s = @inferred SobolSeq(N,lb,ub)
     @test s isa ScaledSobolSeq{Int} && ndims(s) == 3
     @test_throws BoundsError SobolSeq(2,lb,ub)
 end


### PR DESCRIPTION
Currently, the "dimension" of the Sobol sequence is implemented as a static type parameter. However, the whole code never makes any use that the value is known at compile time. Instead, all it does is iterating over `1:ndims` (which will typically be not so small that loop unrolling would be favorable in any way, and the loop bodies are too long for this anyway) and creating vectors of length `ndims`, which turns the static parameter into a runtime variable.

I would say that the whole point why for example `Array` uses a static dimension parameter instead of dynamic ones is:
- code for efficient striding will be different for each dimension count and can then be efficiently compiler-generated and inlined
- the "size" property can be a dimension-sized tuple with a size for each dimension, leading to type stability
- and a very minor point is that dispatch will already do type checking when using arrays of wrong dimension, though since the design decision was made long before JET or PackageCompiler, this is not really be relevant here

For multiple `SobolSeq` of different dimension, instead, the compiler has to regenerate the code for every single method with the only difference between them being an integer constant in the function body, which is very inefficient. On top on this, any package that uses this one and needs to generate a `SobolSeq` with only runtime-known length (actually, I'm here because of `MultistartOptimization.jl`), unavoidably now has type instabilities and uninferrability (or it follows the same approach and "staticizes" the dynamical value, leading to dynamical dispatch and compiler overhead by method generation).
Given that there is no technical reason or benefit for the static type parameter, I propose to change it to a field of the struct instead, which solves all the mentioned problems. `SobolSeq` is now unparametrized and `ScaledSobolSeq` only contains the type of the boundaries as a type parameter.
This is a breaking change if people explicitly wrote `SobolSeq{N}` before, therefore this would be a major version increment.
Note that I increased the Julia version to 1.8 since I declared the `ndims` field `const`; however, this is the only reason for the compatibility reduction and can of course also be removed if you'd rather like to keep compatibility.

Closes #18 as obsolete (see also my comment there).